### PR TITLE
feat: améliorer la découverte automatique des versions Git pour doc-harvester

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,9 @@
 FROM python:3.11-slim
 WORKDIR /app
+
+# installer git (et éventuellement les dépendances nécessaires pour git)
+RUN apt-get update && apt-get install -y git && apt-get clean && rm -rf /var/lib/apt/lists/*
+
 COPY . /app
 RUN pip install fastapi uvicorn weaviate-client pyyaml tqdm requests gitpython
 CMD ["python", "main.py"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,6 +20,9 @@ services:
 
   doc-harvester:
     build: ./
+    dns:
+      - 8.8.8.8
+      - 1.1.1.1
     networks:
       main_network:
         ipv4_address: ${HARVESTER_IP}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,6 +41,6 @@ networks:
   main_network:
     external: true
     name: ${MAIN_NETWORK_NAME}
-harvester_internet:
+  harvester_internet:
     driver: bridge
     internal: false

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,6 +26,7 @@ services:
     networks:
       main_network:
         ipv4_address: ${HARVESTER_IP}
+      harvester_internet:
     environment:
       WEAVIATE_URL: http://weaviate:8080
       EMBEDDER_URL: http://127.0.0.1:11434/api/embeddings
@@ -40,3 +41,7 @@ networks:
   main_network:
     external: true
     name: ${MAIN_NETWORK_NAME}
+harvester_internet:
+    name: harvester_internet
+    driver: bridge
+    internal: false

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,7 +31,7 @@ services:
       WEAVIATE_URL: http://weaviate:8080
       EMBEDDER_URL: http://127.0.0.1:11434/api/embeddings
       MODEL_NAME: nomic-embed-text
-      VERSION_CACHE_TTL: 0
+      VERSION_CACHE_TTL: 60
     volumes:
       - ./cache:/cache
     restart: unless-stopped

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,8 +7,12 @@ services:
         ipv4_address: ${WEAVIATE_IP}
     environment:
       AUTHENTICATION_ANONYMOUS_ACCESS_ENABLED: "true"
-      ENABLE_MODULES: "text2vec-transformers"
       PERSISTENCE_DATA_PATH: /var/lib/weaviate
+      # Désactive les modules ou ne pas inclure text2vec-transformers
+      ENABLE_MODULES: ""
+      DEFAULT_VECTORIZER_MODULE: "none"
+      # Ne pas définir TRANSFORMERS_INFERENCE_API
+      CLUSTER_HOSTNAME: "node1"
     volumes:
       - weaviate_data:/var/lib/weaviate
     restart: unless-stopped

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,7 @@ services:
       PERSISTENCE_DATA_PATH: /var/lib/weaviate
       # Désactive les modules ou ne pas inclure text2vec-transformers
       ENABLE_MODULES: ""
+      DISABLE_TELEMETRY: "true"
       DEFAULT_VECTORIZER_MODULE: "none"
       # Ne pas définir TRANSFORMERS_INFERENCE_API
       CLUSTER_HOSTNAME: "node1"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,6 +31,7 @@ services:
       WEAVIATE_URL: http://weaviate:8080
       EMBEDDER_URL: http://127.0.0.1:11434/api/embeddings
       MODEL_NAME: nomic-embed-text
+      VERSION_CACHE_TTL: 0
     volumes:
       - ./cache:/cache
     restart: unless-stopped

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,6 +42,5 @@ networks:
     external: true
     name: ${MAIN_NETWORK_NAME}
 harvester_internet:
-    name: harvester_internet
     driver: bridge
     internal: false

--- a/harvester/git_manager.py
+++ b/harvester/git_manager.py
@@ -1,20 +1,49 @@
 import os
 import subprocess
 import yaml
-import tempfile
-import shutil
+import time
+import json
+import re
+from packaging import version as packaging_version
 
 BASE_DIR = "/cache/repos"
+CACHE_FILE = "/cache/version_cache.json"
+CACHE_TTL = 365 * 24 * 3600  # 1 an en secondes
+
+SEMVER_TAG_RE = re.compile(r"^(v?\d+\.\d+\.\d+)$")  # ex : "1.2.3" ou "v1.2.3"
+
+def _load_cache():
+    try:
+        with open(CACHE_FILE, "r") as f:
+            data = json.load(f)
+        return data
+    except Exception:
+        return {}
+
+def _save_cache(cache):
+    os.makedirs(os.path.dirname(CACHE_FILE), exist_ok=True)
+    with open(CACHE_FILE, "w") as f:
+        json.dump(cache, f)
 
 def list_versions(lang, limit=10):
-    # lit le repo de base dans sources
     with open("/app/harvester/sources.yaml") as f:
         sources = yaml.safe_load(f)
     if lang not in sources:
         raise ValueError(f"Unsupported language: {lang}")
     repo = sources[lang]["repo"]
-    # on utilise git ls-remote pour lister tags et branches
-    result = subprocess.run(["git", "ls-remote", "--refs", "--tags", repo], capture_output=True, text=True, check=True)
+
+    cache = _load_cache()
+    entry = cache.get(lang)
+
+    now = time.time()
+    if entry and (now - entry.get("ts", 0) < CACHE_TTL):
+        # cache encore valide
+        return entry.get("versions", [])[:limit]
+
+    # sinon, mettre à jour le cache
+    # lister les tags
+    result = subprocess.run(["git", "ls-remote", "--refs", "--tags", repo],
+                             capture_output=True, text=True, check=True)
     lines = result.stdout.strip().splitlines()
     tags = []
     for line in lines:
@@ -24,21 +53,45 @@ def list_versions(lang, limit=10):
         ref = parts[1]
         if ref.startswith("refs/tags/"):
             tag = ref[len("refs/tags/"):]
-            tags.append(tag)
-    # optionnel : trier les tags (selon version semver)
-    # garder les plus récents
-    tags = sorted(tags, reverse=True)[:limit]
-    # ajouter la branche principale (main / master) si elle existe
-    # pour ça on peut tester l'existence avec ls-remote
+            # filtrer selon regex semver
+            m = SEMVER_TAG_RE.match(tag)
+            if m:
+                # enlever “v” si présent
+                cleaned = tag.lstrip("v")
+                tags.append(cleaned)
+
+    # trier selon semver
+    try:
+        tags = sorted(tags, key=packaging_version.parse, reverse=True)
+    except Exception:
+        tags = sorted(tags, reverse=True)
+
+    # unique, limiter
+    unique = []
+    for t in tags:
+        if t not in unique:
+            unique.append(t)
+    top = unique[:limit]
+
+    # détecter branche “main” ou “master”
     branch_main = None
     for br in ["main", "master"]:
-        r = subprocess.run(["git", "ls-remote", "--heads", repo, br], capture_output=True, text=True)
+        r = subprocess.run(["git", "ls-remote", "--heads", repo, br],
+                           capture_output=True, text=True)
         if r.stdout.strip():
             branch_main = br
             break
+
+    versions = []
     if branch_main:
-        tags.insert(0, branch_main)
-    return tags
+        versions.append(branch_main)
+    versions += top
+
+    # enregistrer cache
+    cache[lang] = {"ts": now, "versions": versions}
+    _save_cache(cache)
+
+    return versions
 
 def clone_repo(lang, version):
     with open("/app/harvester/sources.yaml") as f:
@@ -47,11 +100,19 @@ def clone_repo(lang, version):
         raise ValueError(f"Unsupported language: {lang}")
     repo = sources[lang]["repo"]
     path_in_repo = sources[lang].get("path", "")
-    # si version est “latest” ou “main” ou “master”, on utilise la branche principale
-    # sinon version = tag
+
+    # vérifier version dans la liste autorisée
+    allowed = list_versions(lang, limit=50)
+    # si version est “latest”, on prend la première de la liste
+    if version == "latest":
+        version = allowed[0] if allowed else version
+    if version not in allowed:
+        raise ValueError(f"Version {version} not in allowed list for {lang}")
+
     target_dir = os.path.join(BASE_DIR, f"{lang}_{version}")
     if not os.path.exists(target_dir):
         os.makedirs(BASE_DIR, exist_ok=True)
-        # clonage profond minimal
+        # clonage minimal
         subprocess.run(["git", "clone", "--depth", "1", "--branch", version, repo, target_dir], check=True)
+
     return os.path.join(target_dir, path_in_repo)

--- a/harvester/git_manager.py
+++ b/harvester/git_manager.py
@@ -91,9 +91,15 @@ def list_versions(lang, limit=10):
         if v not in ordered:
             ordered.append(v)
 
-    cache[lang] = {"ts": now, "versions": ordered}
+    # On veut que les derniers tags apparaissent en premier : inverser l’ordre des “autres”
+    base = [v for v in ordered if v in ("main", "master")]
+    rest = [v for v in ordered if v not in ("main", "master")]
+    rest.reverse()
+    final = base + rest
+
+    cache[lang] = {"ts": now, "versions": final}
     _save_cache(cache)
-    return ordered[:limit]
+    return final[:limit]
 
 def clone_repo(lang, version):
     with open("/app/harvester/sources.yaml") as f:

--- a/harvester/git_manager.py
+++ b/harvester/git_manager.py
@@ -12,7 +12,7 @@ def _load_cache():
     try:
         with open(CACHE_FILE, "r") as f:
             return json.load(f)
-    except:
+    except Exception:
         return {}
 
 def _save_cache(cache):
@@ -33,19 +33,20 @@ def list_versions(lang, limit=10):
     if entry and (now - entry.get("ts", 0) < CACHE_TTL):
         return entry.get("versions", [])[:limit]
 
-    # fetch raw refs (tags + branches)
-    result_tags = subprocess.run(
+    # obtenir tags
+    res_tags = subprocess.run(
         ["git", "ls-remote", "--refs", "--tags", repo],
         capture_output=True, text=True, check=True
     ).stdout.strip().splitlines()
-    result_heads = subprocess.run(
+    # obtenir branches (heads)
+    res_heads = subprocess.run(
         ["git", "ls-remote", "--heads", repo],
         capture_output=True, text=True, check=True
     ).stdout.strip().splitlines()
 
     versions = []
     # parse tags
-    for line in result_tags:
+    for line in res_tags:
         parts = line.split()
         if len(parts) < 2:
             continue
@@ -53,8 +54,8 @@ def list_versions(lang, limit=10):
         if ref.startswith("refs/tags/"):
             tag = ref[len("refs/tags/"):]
             versions.append(tag)
-    # parse branches (heads)
-    for line in result_heads:
+    # parse branches
+    for line in res_heads:
         parts = line.split()
         if len(parts) < 2:
             continue
@@ -63,27 +64,24 @@ def list_versions(lang, limit=10):
             branch = ref[len("refs/heads/"):]
             versions.append(branch)
 
-    # unique
+    # unique (conserver premier apparition)
     unique = []
     for v in versions:
         if v not in unique:
             unique.append(v)
 
-    # optional: put “main” / “master” first if present
-    prioritized = []
+    # prioriser “main” / “master” s’ils existent
+    ordered = []
     for b in ["main", "master"]:
         if b in unique:
-            prioritized.append(b)
-    # then append other versions (except those two, already in prioritized)
+            ordered.append(b)
     for v in unique:
-        if v not in prioritized:
-            prioritized.append(v)
+        if v not in ordered:
+            ordered.append(v)
 
-    # cache
-    cache[lang] = {"ts": now, "versions": prioritized}
+    cache[lang] = {"ts": now, "versions": ordered}
     _save_cache(cache)
-
-    return prioritized[:limit]
+    return ordered[:limit]
 
 def clone_repo(lang, version):
     with open("/app/harvester/sources.yaml") as f:

--- a/harvester/git_manager.py
+++ b/harvester/git_manager.py
@@ -6,7 +6,7 @@ import json
 
 BASE_DIR = "/cache/repos"
 CACHE_FILE = "/cache/version_cache.json"
-CACHE_TTL = 365 * 24 * 3600  # 1 an
+CACHE_TTL = int(os.getenv("VERSION_CACHE_TTL", 365 * 24 * 3600))
 
 def _load_cache():
     try:

--- a/harvester/git_manager.py
+++ b/harvester/git_manager.py
@@ -1,6 +1,44 @@
-import os, subprocess, yaml
+import os
+import subprocess
+import yaml
+import tempfile
+import shutil
 
 BASE_DIR = "/cache/repos"
+
+def list_versions(lang, limit=10):
+    # lit le repo de base dans sources
+    with open("/app/harvester/sources.yaml") as f:
+        sources = yaml.safe_load(f)
+    if lang not in sources:
+        raise ValueError(f"Unsupported language: {lang}")
+    repo = sources[lang]["repo"]
+    # on utilise git ls-remote pour lister tags et branches
+    result = subprocess.run(["git", "ls-remote", "--refs", "--tags", repo], capture_output=True, text=True, check=True)
+    lines = result.stdout.strip().splitlines()
+    tags = []
+    for line in lines:
+        parts = line.split()
+        if len(parts) < 2:
+            continue
+        ref = parts[1]
+        if ref.startswith("refs/tags/"):
+            tag = ref[len("refs/tags/"):]
+            tags.append(tag)
+    # optionnel : trier les tags (selon version semver)
+    # garder les plus récents
+    tags = sorted(tags, reverse=True)[:limit]
+    # ajouter la branche principale (main / master) si elle existe
+    # pour ça on peut tester l'existence avec ls-remote
+    branch_main = None
+    for br in ["main", "master"]:
+        r = subprocess.run(["git", "ls-remote", "--heads", repo, br], capture_output=True, text=True)
+        if r.stdout.strip():
+            branch_main = br
+            break
+    if branch_main:
+        tags.insert(0, branch_main)
+    return tags
 
 def clone_repo(lang, version):
     with open("/app/harvester/sources.yaml") as f:
@@ -8,9 +46,12 @@ def clone_repo(lang, version):
     if lang not in sources:
         raise ValueError(f"Unsupported language: {lang}")
     repo = sources[lang]["repo"]
-    tag = version if version != "latest" else sources[lang]["versions"][0]
-    target_dir = f"{BASE_DIR}/{lang}_{tag}"
+    path_in_repo = sources[lang].get("path", "")
+    # si version est “latest” ou “main” ou “master”, on utilise la branche principale
+    # sinon version = tag
+    target_dir = os.path.join(BASE_DIR, f"{lang}_{version}")
     if not os.path.exists(target_dir):
         os.makedirs(BASE_DIR, exist_ok=True)
-        subprocess.run(["git", "clone", "--depth=1", "--branch", tag, repo, target_dir], check=True)
-    return os.path.join(target_dir, sources[lang]["path"])
+        # clonage profond minimal
+        subprocess.run(["git", "clone", "--depth", "1", "--branch", version, repo, target_dir], check=True)
+    return os.path.join(target_dir, path_in_repo)

--- a/harvester/parser.py
+++ b/harvester/parser.py
@@ -2,14 +2,11 @@ import os
 from pathlib import Path
 import re
 
-MAX_CHUNK_SIZE = 20000  # limite taille d’un chunk
+MAX_CHUNK_SIZE = 20000
 
 def sanitize_text(text: str) -> str:
-    # enlever les caractères non imprimables
     text = ''.join(ch for ch in text if ch.isprintable() or ch in "\n\t")
-    # remplacer plusieurs espaces
     text = re.sub(r"[ \t]{2,}", " ", text)
-    # optionnel : retirer les blocs HTML ou scripts (simple heuristique)
     text = re.sub(r"<[^>]+>", "", text)
     return text.strip()
 
@@ -26,11 +23,9 @@ def extract_docs(repo_path):
                 text = sanitize_text(raw)
                 if len(text) < 50:
                     continue
-                # éventuellement découper en chunks
-                # si trop long
                 if len(text) > MAX_CHUNK_SIZE:
                     for i in range(0, len(text), MAX_CHUNK_SIZE):
-                        docs.append({"text": text[i:i+MAX_CHUNK_SIZE], "source": str(path)})
+                        docs.append({"text": text[i : i + MAX_CHUNK_SIZE], "source": str(path)})
                 else:
                     docs.append({"text": text, "source": str(path)})
     return docs

--- a/harvester/sources.yaml
+++ b/harvester/sources.yaml
@@ -1,27 +1,15 @@
 go:
   repo: "https://github.com/golang/go.git"
   path: "doc"
-  versions:
-    - "go1.22.3"
-    - "go1.21.10"
 
 tinygo:
   repo: "https://github.com/tinygo-org/tinygo.git"
   path: "src/runtime"
-  versions:
-    - "v0.32.0"
-    - "v0.31.2"
 
 php:
   repo: "https://github.com/php/doc-en.git"
   path: "en"
-  versions:
-    - "php-8.3"
-    - "php-8.2"
 
 react:
   repo: "https://github.com/reactjs/react.dev.git"
   path: "src/content"
-  versions:
-    - "main"
-    - "v18"

--- a/harvester/sources.yaml
+++ b/harvester/sources.yaml
@@ -1,15 +1,19 @@
 go:
   repo: "https://github.com/golang/go.git"
   path: "doc"
+  ignore_branches: true
 
 tinygo:
   repo: "https://github.com/tinygo-org/tinygo.git"
   path: "src/runtime"
+  ignore_branches: false
 
 php:
   repo: "https://github.com/php/doc-en.git"
   path: "en"
+  ignore_branches: true
 
 react:
   repo: "https://github.com/reactjs/react.dev.git"
   path: "src/content"
+  ignore_branches: false

--- a/harvester/sources.yaml
+++ b/harvester/sources.yaml
@@ -2,24 +2,26 @@ go:
   repo: "https://github.com/golang/go.git"
   path: "doc"
   ignore_branches: true
-  # filtre : seuls les tags “goX.Y” ou “goX.Y.Z”
+  # filtre regex pour versions stables
   version_filter: "^go\\d+\\.\\d+(?:\\.\\d+)?$"
+  # préfixe à retirer pour le tri / parsing
+  version_prefix: "go"
 
 tinygo:
   repo: "https://github.com/tinygo-org/tinygo.git"
   path: "src/runtime"
   ignore_branches: true
-  # filtre pour “vX.Y.Z” ou tags réguliers
   version_filter: "^(?:v?\\d+\\.\\d+\\.\\d+)$"
+  version_prefix: "v"   # ou "" si pas de préfixe
 
 php:
   repo: "https://github.com/php/doc-en.git"
   path: "en"
   ignore_branches: true
-  version_filter: "^php-\\d+\\.\\d+$"   # ex : php-8.3
+  version_filter: "^php-\\d+\\.\\d+$"
+  version_prefix: "php-"
 
 react:
   repo: "https://github.com/reactjs/react.dev.git"
   path: "src/content"
-  # ici on accepte branches / tags, pas de filtre
-  # version_filter absent = pas de filtre
+  # pas de version_filter ou version_prefix => pas de retrait du préfixe

--- a/harvester/sources.yaml
+++ b/harvester/sources.yaml
@@ -2,18 +2,24 @@ go:
   repo: "https://github.com/golang/go.git"
   path: "doc"
   ignore_branches: true
+  # filtre : seuls les tags “goX.Y” ou “goX.Y.Z”
+  version_filter: "^go\\d+\\.\\d+(?:\\.\\d+)?$"
 
 tinygo:
   repo: "https://github.com/tinygo-org/tinygo.git"
   path: "src/runtime"
-  ignore_branches: false
+  ignore_branches: true
+  # filtre pour “vX.Y.Z” ou tags réguliers
+  version_filter: "^(?:v?\\d+\\.\\d+\\.\\d+)$"
 
 php:
   repo: "https://github.com/php/doc-en.git"
   path: "en"
   ignore_branches: true
+  version_filter: "^php-\\d+\\.\\d+$"   # ex : php-8.3
 
 react:
   repo: "https://github.com/reactjs/react.dev.git"
   path: "src/content"
-  ignore_branches: false
+  # ici on accepte branches / tags, pas de filtre
+  # version_filter absent = pas de filtre

--- a/harvester/vectorizer.py
+++ b/harvester/vectorizer.py
@@ -2,17 +2,31 @@ import os, requests, weaviate
 from tqdm import tqdm
 
 client = weaviate.Client(os.environ["WEAVIATE_URL"])
-OLLAMA_URL = os.getenv("EMBEDDER_URL", "http://127.0.0.1:11434/api/embeddings")
+OLLAMA_URL = os.getenv("EMBEDDER_URL", "http://192.168.1.156:11535/api/embeddings")
 MODEL_NAME = os.getenv("MODEL_NAME", "nomic-embed-text")
 
 def push_to_weaviate(docs, lang, version):
     for doc in tqdm(docs, desc=f"Ingesting {lang}@{version}"):
-        r = requests.post(OLLAMA_URL, json={"model": MODEL_NAME, "input": doc["text"][:8000]})
-        embedding = r.json().get("embedding", [])
+        payload = {"model": MODEL_NAME, "input": doc["text"][:8000]}
+        try:
+            r = requests.post(OLLAMA_URL, json=payload)
+            r.raise_for_status()
+            embedding = r.json().get("embedding")
+            if embedding is None:
+                # skip si embed non fourni
+                continue
+        except Exception as e:
+            print(f"Embedding failed for {doc['source']}: {e}")
+            continue
+
         data = {
             "text": doc["text"],
             "lang": lang,
             "version": version,
             "source": doc["source"],
         }
-        client.data_object.create(data, "Documentation", vector=embedding)
+        try:
+            client.data_object.create(data, "Documentation", vector=embedding)
+        except Exception as e:
+            print(f"Weaviate insertion failed for {doc['source']}: {e}")
+            continue

--- a/harvester/vectorizer.py
+++ b/harvester/vectorizer.py
@@ -1,32 +1,46 @@
-import os, requests, weaviate
+import os
+import requests
+from weaviate import connect, WeaviateClient
+from weaviate.connect import ConnectionParams
 from tqdm import tqdm
 
-client = weaviate.Client(os.environ["WEAVIATE_URL"])
-OLLAMA_URL = os.getenv("EMBEDDER_URL", "http://192.168.1.156:11535/api/embeddings")
+# Exemple d'initialisation avec v4
+def get_weaviate_client():
+    weaviate_url = os.environ["WEAVIATE_URL"]  # ex: "http://weaviate:8080"
+    # On suppose que le grpc port est 50051 (par défaut pour Weaviate)
+    # Si tu l’as mappé dans Docker compose, ça doit être exposé.
+    conn = ConnectionParams.from_url(weaviate_url, grpc_port=50051)
+    client = WeaviateClient(conn, skip_init_checks=False)
+    return client
+
+client = get_weaviate_client()
+
+OLLAMA_URL = os.getenv("EMBEDDER_URL", "http://127.0.0.1:11434/api/embeddings")
 MODEL_NAME = os.getenv("MODEL_NAME", "nomic-embed-text")
 
 def push_to_weaviate(docs, lang, version):
-    for doc in tqdm(docs, desc=f"Ingesting {lang}@{version}"):
-        payload = {"model": MODEL_NAME, "input": doc["text"][:8000]}
-        try:
-            r = requests.post(OLLAMA_URL, json=payload)
-            r.raise_for_status()
-            embedding = r.json().get("embedding")
-            if embedding is None:
-                # skip si embed non fourni
+    # On peut utiliser batch pour insertion efficace
+    with client.batch.dynamic() as batch:
+        for doc in tqdm(docs, desc=f"Ingesting {lang}@{version}"):
+            payload = {"model": MODEL_NAME, "input": doc["text"][:8000]}
+            try:
+                r = requests.post(OLLAMA_URL, json=payload)
+                r.raise_for_status()
+                embedding = r.json().get("embedding")
+                if embedding is None:
+                    continue
+            except Exception as e:
+                print(f"Embedding failed for {doc['source']}: {e}")
                 continue
-        except Exception as e:
-            print(f"Embedding failed for {doc['source']}: {e}")
-            continue
 
-        data = {
-            "text": doc["text"],
-            "lang": lang,
-            "version": version,
-            "source": doc["source"],
-        }
-        try:
-            client.data_object.create(data, "Documentation", vector=embedding)
-        except Exception as e:
-            print(f"Weaviate insertion failed for {doc['source']}: {e}")
-            continue
+            properties = {
+                "text": doc["text"],
+                "lang": lang,
+                "version": version,
+                "source": doc["source"],
+            }
+            try:
+                batch.add_object(properties=properties, class_name="Documentation", vector=embedding)
+            except Exception as e:
+                print(f"Weaviate insertion failed for {doc['source']}: {e}")
+                continue

--- a/harvester/vectorizer.py
+++ b/harvester/vectorizer.py
@@ -4,11 +4,8 @@ from weaviate import connect, WeaviateClient
 from weaviate.connect import ConnectionParams
 from tqdm import tqdm
 
-# Exemple d'initialisation avec v4
 def get_weaviate_client():
-    weaviate_url = os.environ["WEAVIATE_URL"]  # ex: "http://weaviate:8080"
-    # On suppose que le grpc port est 50051 (par défaut pour Weaviate)
-    # Si tu l’as mappé dans Docker compose, ça doit être exposé.
+    weaviate_url = os.environ["WEAVIATE_URL"]
     conn = ConnectionParams.from_url(weaviate_url, grpc_port=50051)
     client = WeaviateClient(conn, skip_init_checks=False)
     return client
@@ -19,7 +16,6 @@ OLLAMA_URL = os.getenv("EMBEDDER_URL", "http://127.0.0.1:11434/api/embeddings")
 MODEL_NAME = os.getenv("MODEL_NAME", "nomic-embed-text")
 
 def push_to_weaviate(docs, lang, version):
-    # On peut utiliser batch pour insertion efficace
     with client.batch.dynamic() as batch:
         for doc in tqdm(docs, desc=f"Ingesting {lang}@{version}"):
             payload = {"model": MODEL_NAME, "input": doc["text"][:8000]}

--- a/main.py
+++ b/main.py
@@ -1,5 +1,5 @@
-from fastapi import FastAPI, Query
-from harvester.git_manager import clone_repo
+from fastapi import FastAPI, Query, HTTPException
+from harvester.git_manager import list_versions, clone_repo
 from harvester.parser import extract_docs
 from harvester.vectorizer import push_to_weaviate
 import uvicorn
@@ -8,15 +8,23 @@ app = FastAPI(title="Doc Harvester")
 
 @app.get("/versions")
 def versions(lang: str = Query(...), limit: int = Query(10)):
-    # retourne les versions disponibles
-    return {"lang": lang, "versions": list_versions(lang, limit)}
+    try:
+        vers = list_versions(lang, limit)
+        return {"lang": lang, "versions": vers}
+    except Exception as e:
+        raise HTTPException(status_code=400, detail=str(e))
 
 @app.get("/fetch")
 def fetch_docs(lang: str = Query(...), version: str = Query("latest")):
-    repo_path = clone_repo(lang, version)
-    docs = extract_docs(repo_path)
-    push_to_weaviate(docs, lang, version)
-    return {"status": "ok", "count": len(docs), "lang": lang, "version": version}
+    try:
+        repo_path = clone_repo(lang, version)
+        docs = extract_docs(repo_path)
+        push_to_weaviate(docs, lang, version)
+        return {"status": "ok", "count": len(docs), "lang": lang, "version": version}
+    except ValueError as ve:
+        raise HTTPException(status_code=400, detail=str(ve))
+    except Exception as e:
+        raise HTTPException(status_code=500, detail="Internal error: " + str(e))
 
 if __name__ == "__main__":
     uvicorn.run(app, host="0.0.0.0", port=8090)

--- a/main.py
+++ b/main.py
@@ -6,6 +6,11 @@ import uvicorn
 
 app = FastAPI(title="Doc Harvester")
 
+@app.get("/versions")
+def versions(lang: str = Query(...), limit: int = Query(10)):
+    # retourne les versions disponibles
+    return {"lang": lang, "versions": list_versions(lang, limit)}
+
 @app.get("/fetch")
 def fetch_docs(lang: str = Query(...), version: str = Query("latest")):
     repo_path = clone_repo(lang, version)


### PR DESCRIPTION
- Le service ne renvoyait que l’élément “master” malgré la présence de nombreux tags Git
- L’ordre des versions renvoyées était inversé (avec les très anciennes versions remontées en premier)
- Le filtrage actuel des versions (tags + branches) était rigide, et non configurable par langage
- Le préfixe (go, v, etc.) n’était pas pris en compte dans le tri, ce qui faussait la hiérarchie des versions
- Le cache de versions était une constante codée en dur, sans possibilité de l’ajuster
- Il n’y avait pas d’option pour ignorer les branches dans la récupération des versions